### PR TITLE
Mm 371 fix wrong mixpanel events tracking on mobile

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,9 +44,9 @@ Future<void> main() async {
 
   final authState = AuthState();
   final localAuth = LocalAuth();
-  final mixpanelManager = AnalyticManager();
-  final appRepository = AppRepository(sdk, mixpanelManager);
-  mixpanelManager.keysharesProvider = appRepository.keysharesProvider;
+  final analyticManager = AnalyticManager();
+  final appRepository = AppRepository(sdk, analyticManager);
+  analyticManager.keysharesProvider = appRepository.keysharesProvider;
   final appPreferences = AppPreferences(sharedPreferences);
   final firebaseMessaging = MessagingService(authState, appRepository);
   firebaseMessaging.start();
@@ -56,7 +56,7 @@ Future<void> main() async {
   await secureStorage.init();
 
   final fileService = FileService();
-  final backupService = BackupService(fileService, secureStorage, appPreferences);
+  final backupService = BackupService(fileService, secureStorage, appPreferences, analyticManager);
   final themeManager = ThemeManager();
 
   // Initiate the anonymous sign in process
@@ -77,7 +77,7 @@ Future<void> main() async {
         Provider(create: (_) => appRepository),
         Provider(create: (_) => signInService),
         Provider(create: (_) => secureStorage as SecureStorageService), // ignore: unnecessary_cast
-        Provider(create: (_) => mixpanelManager),
+        Provider(create: (_) => analyticManager),
         ChangeNotifierProvider(create: (_) => backupService), // ignore: unnecessary_cast
         ChangeNotifierProvider(create: (_) => appPreferences),
         ChangeNotifierProvider(create: (_) => appRepository.pairingDataProvider),

--- a/lib/screens/pairing/pair_screen.dart
+++ b/lib/screens/pairing/pair_screen.dart
@@ -99,11 +99,6 @@ class _PairState extends State<PairScreen> {
     } catch (error) {
       _showError(error, source);
       print('Error recovering from credentionals: $error');
-      if (source == BackupSource.secureStorage) {
-        analyticManager.trackRecoverBackupSystem(success: false, source: PageSource.get_started, error: error.toString());
-      } else {
-        analyticManager.trackRecoverFromFile(success: false, source: PageSource.get_started, error: error.toString());
-      }
     } finally {
       setState(() => _pairingState = PairingState.ready);
     }
@@ -161,11 +156,6 @@ class _PairState extends State<PairScreen> {
   }
 
   void _recoverFromBackup(AppBackup backup, BackupSource source) {
-    if (source == BackupSource.secureStorage) {
-      analyticManager.trackRecoverBackupSystem(success: true, source: PageSource.get_started);
-    } else {
-      analyticManager.trackRecoverFromFile(success: true, source: PageSource.get_started);
-    }
     Navigator.push(
       context,
       MaterialPageRoute(

--- a/lib/screens/sign/transaction_details_widget.dart
+++ b/lib/screens/sign/transaction_details_widget.dart
@@ -9,7 +9,6 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:slide_to_act/slide_to_act.dart';
 
-import '../../third_party/analytics.dart';
 import '../../constants.dart';
 import '../../demo/state_decorators/keyshares_provider.dart';
 import '../../utils.dart';
@@ -30,7 +29,6 @@ class TransactionDetailsWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     TextTheme textTheme = Theme.of(context).textTheme;
     var outputFormat = DateFormat('hh:mm a, dd/MM/yyyy ');
-    final analyticManager = Provider.of<AnalyticManager>(context, listen: false);
 
     return SizedBox(
       width: MediaQuery.of(context).size.width,
@@ -219,18 +217,13 @@ class TransactionDetailsWidget extends StatelessWidget {
                 textStyle: textTheme.displaySmall,
                 sliderButtonIconSize: 20,
                 onSubmit: () {
-                  analyticManager.trackSignPerform(status: SignPerformStatus.approved);
-                  handleSignResponse(true, requestModel, onErrorCb: (error) {
-                    analyticManager.trackSignPerform(status: SignPerformStatus.failed, error: error.toString());
-                  });
-                  analyticManager.trackSignPerform(status: SignPerformStatus.success);
+                  handleSignResponse(true, requestModel);
                   return null;
                 },
               ),
               TextButton(
                   onPressed: () {
                     handleSignResponse(false, requestModel);
-                    analyticManager.trackSignPerform(status: SignPerformStatus.rejected);
                   },
                   child: const Text(
                     'Reject',

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:credential_manager/credential_manager.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:silentshard/third_party/analytics.dart';
 
 import 'app_preferences.dart';
@@ -61,6 +62,8 @@ class BackupService extends ChangeNotifier {
         _analyticManager.trackRecoverBackupSystem(success: true, source: PageSource.get_started);
         return AppBackup.fromString(entry.value);
       }
+    } on PlatformException catch (error) {
+      _analyticManager.trackRecoverBackupSystem(success: false, source: PageSource.get_started, error: error.details);
     } catch (error) {
       _analyticManager.trackRecoverBackupSystem(success: false, source: PageSource.get_started, error: error.toString());
       rethrow;

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -45,8 +45,9 @@ class BackupService extends ChangeNotifier {
       backupDestination = filePickerId;
       if (file != null) {
         final fileContent = await file.readAsString();
+        final appBackup = AppBackup.fromString(fileContent);
         _analyticManager.trackRecoverFromFile(success: true, source: PageSource.get_started, backup: backupDestination);
-        return AppBackup.fromString(fileContent);
+        return appBackup;
       }
     } catch (error) {
       _analyticManager.trackRecoverFromFile(success: false, source: PageSource.get_started, backup: backupDestination, error: error.toString());

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:credential_manager/credential_manager.dart';
 import 'package:flutter/material.dart';
+import 'package:silentshard/third_party/analytics.dart';
 
 import 'app_preferences.dart';
 import '../types/backup_info.dart';
@@ -20,11 +21,12 @@ class BackupService extends ChangeNotifier {
   final FileService _fileService;
   final SecureStorageService _secureStorage;
   final AppPreferences _preferences;
+  final AnalyticManager _analyticManager;
 
   // Optimization to fetch backup from keychain only once per launch
   final Map<String, bool> _hasCheckedKeychain = {};
 
-  BackupService(this._fileService, this._secureStorage, this._preferences);
+  BackupService(this._fileService, this._secureStorage, this._preferences, this._analyticManager);
 
   // -------------------- Read --------------------
 

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -60,8 +60,9 @@ class BackupService extends ChangeNotifier {
     try {
       final entry = await _secureStorage.read(key);
       if (entry != null) {
+        final appBackup = AppBackup.fromString(entry.value);
         _analyticManager.trackRecoverBackupSystem(success: true, source: PageSource.get_started);
-        return AppBackup.fromString(entry.value);
+        return appBackup;
       }
     } on PlatformException catch (error) {
       _analyticManager.trackRecoverBackupSystem(success: false, source: PageSource.get_started, error: error.details);

--- a/lib/services/backup_use_cases.dart
+++ b/lib/services/backup_use_cases.dart
@@ -75,12 +75,11 @@ class ExportBackupUseCase extends UseCase {
           subject: tempFile.filename,
           sharePositionOrigin: isIPad ? box.localToGlobal(Offset.zero) & box.size : null,
         );
-        ;
         if (result.status != ShareResultStatus.dismissed) {
-          analyticManager.trackSaveToFile(success: true, source: PageSource.backup_page);
+          analyticManager.trackSaveToFile(success: true, source: PageSource.backup_page, backup: result.raw);
           backupService.backupToFileDidSave(appBackup);
         } else {
-          analyticManager.trackSaveToFile(success: false, source: PageSource.backup_page, error: "Save to file is dismissed.");
+          analyticManager.trackSaveToFile(success: false, source: PageSource.backup_page, backup: result.raw, error: "Save to file is dismissed.");
         }
       }
     } catch (e) {

--- a/lib/services/file_service.dart
+++ b/lib/services/file_service.dart
@@ -11,7 +11,6 @@ class FileService {
     return FilePicker.platform.pickFiles().then((value) {
       final path = value?.files.single.path;
       final filePickerId = _removeEmailFrom(value?.files.single.identifier ?? '');
-
       return (path != null) ? (File(path), filePickerId) : (null, null);
     });
   }
@@ -24,7 +23,7 @@ class FileService {
 
 String _removeEmailFrom(String identifier) {
   RegExp emailRegex = RegExp(
-    r'\b[A-Za-z0-9._%+-]+%40[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
+    r'\b[A-Za-z0-9._%+-]+%2540[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
     caseSensitive: false,
     multiLine: false,
   );

--- a/lib/services/file_service.dart
+++ b/lib/services/file_service.dart
@@ -7,10 +7,11 @@ import 'package:file_picker/file_picker.dart';
 import 'package:path_provider/path_provider.dart';
 
 class FileService {
-  Future<File?> selectFile() {
+  Future<(File?, String?)> selectFile() {
     return FilePicker.platform.pickFiles().then((value) {
       final path = value?.files.single.path;
-      return (path != null) ? File(path) : null;
+      final filePickerId = value?.files.single.identifier;
+      return (path != null) ? (File(path), filePickerId) : (null, null);
     });
   }
 

--- a/lib/services/file_service.dart
+++ b/lib/services/file_service.dart
@@ -10,7 +10,8 @@ class FileService {
   Future<(File?, String?)> selectFile() {
     return FilePicker.platform.pickFiles().then((value) {
       final path = value?.files.single.path;
-      final filePickerId = value?.files.single.identifier;
+      final filePickerId = _removeEmailFrom(value?.files.single.identifier ?? '');
+
       return (path != null) ? (File(path), filePickerId) : (null, null);
     });
   }
@@ -19,4 +20,14 @@ class FileService {
     return getTemporaryDirectory() //
         .then((tempDirectory) => File('${tempDirectory.path}/$filename.txt'));
   }
+}
+
+String _removeEmailFrom(String identifier) {
+  RegExp emailRegex = RegExp(
+    r'\b[A-Za-z0-9._%+-]+%40[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
+    caseSensitive: false,
+    multiLine: false,
+  );
+
+  return identifier.replaceAll(emailRegex, '');
 }

--- a/lib/third_party/analytics.dart
+++ b/lib/third_party/analytics.dart
@@ -40,11 +40,13 @@ enum EventName {
   distributed_keys_generated,
   account_created,
   save_backup_system,
+  recover_backup_system,
   allow_permissions,
   sign_initiated,
   sign_perform,
   device_lock_toggle,
   save_to_file,
+  recover_from_file,
   delete_account,
   log_out,
   verify_backup
@@ -105,12 +107,7 @@ class AnalyticManager {
   }
 
   void trackSaveBackupSystem({required bool success, required PageSource source, String? wallet, String? error}) {
-    String backup = 'na';
-    if (Platform.isAndroid) {
-      backup = SaveBackupSystem.google_password.name;
-    } else if (Platform.isIOS) {
-      backup = SaveBackupSystem.keychain.name;
-    }
+    String backup = _getBackupSystem();
     mixpanel.track(EventName.save_backup_system.name, properties: {
       'backup': backup,
       'success': success,
@@ -122,13 +119,8 @@ class AnalyticManager {
   }
 
   void trackRecoverBackupSystem({required bool success, required PageSource source, String? wallet, String? error}) {
-    String backup = 'na';
-    if (Platform.isAndroid) {
-      backup = SaveBackupSystem.google_password.name;
-    } else if (Platform.isIOS) {
-      backup = SaveBackupSystem.keychain.name;
-    }
-    mixpanel.track(EventName.save_backup_system.name, properties: {
+    String backup = _getBackupSystem();
+    mixpanel.track(EventName.recover_backup_system.name, properties: {
       'backup': backup,
       'success': success,
       'error': error,
@@ -175,7 +167,7 @@ class AnalyticManager {
   }
 
   void trackRecoverFromFile({required bool success, String? backup, String? wallet, required PageSource source, String? error}) {
-    mixpanel.track(EventName.save_to_file.name, properties: {
+    mixpanel.track(EventName.recover_from_file.name, properties: {
       'backup': backup,
       'success': success,
       'error': error,
@@ -200,12 +192,7 @@ class AnalyticManager {
   }
 
   void trackVerifyBackup({required bool success, required String timeSinceVerify, PageSource? source, String? wallet, String? error}) {
-    String backup = 'na';
-    if (Platform.isAndroid) {
-      backup = SaveBackupSystem.google_password.name;
-    } else if (Platform.isIOS) {
-      backup = SaveBackupSystem.keychain.name;
-    }
+    String backup = _getBackupSystem();
     mixpanel.track(EventName.verify_backup.name, properties: {
       'backup': backup,
       'success': success,
@@ -219,5 +206,14 @@ class AnalyticManager {
 
   String? _getWalletAddress() {
     return _keysharesProvider.keyshares.firstOrNull?.ethAddress;
+  }
+
+  String _getBackupSystem() {
+    if (Platform.isAndroid) {
+      return SaveBackupSystem.google_password.name;
+    } else if (Platform.isIOS) {
+      return SaveBackupSystem.keychain.name;
+    }
+    return 'na';
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -198,7 +198,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: abaeb94640d18fb9b3d0a6104640888e3ada3b4c
+      resolved-ref: a03ff175a23eb0371d84f5c76aaf28f2d35c1637
       url: "git@github.com:silence-laboratories/silent-shard-flutter-sdk.git"
     source: git
     version: "0.0.1"


### PR DESCRIPTION
Fixes:
- Mismatch event name between “recover_backup_system/recover_from_file” and “save_backup_system/save_to_file”
- Events “sign_perform” failed and success is not tracked correctly

Updates:
- Add backup destination into "backup" field of "save_to_file" and "recover_from_file"  when saving backup as files